### PR TITLE
Re-named module to comply with TFC requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# do-apps-tf
+# terraform-digitalocean-static-site
 
 [Terraform](https://www.terraform.io) module for deploying static sites on [DigitalOcean's App Platform](https://www.digitalocean.com/products/app-platform), with support for [Cloudflare](https://cloudflare.com) DNS.
 
@@ -6,7 +6,7 @@
 Create a `.tf` file inside your root module to call the module and set variables:
 ```
 module "static_site" {
-	source = "github.com/m4xmorris/do-apps-tf.git?ref=v1.0.0" # <-- Change this to the desired version
+	source = "github.com/m4xmorris/terraform-digitalocean-static-site.git?ref=v2.0.0" # <-- Change this to the desired version
 	site_name = ""
 	description = ""
 	environment = ""

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "default_ingress" {
     value = digitalocean_app.site_app.default_ingress
+    description = "Default ingress URL for site"
     depends_on = [digitalocean_app.site_app]
 }


### PR DESCRIPTION
To import modules to Terraform Cloud, naming convention must follow `terraform-<main-provider>-<module-name>.
Renamed this repo from "do-apps-tf" to "terraform-digitalocean-static-site" to comply.