### PR TITLE
Updated README.md to match new design.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,3 @@ Optionally, this module is able to automatically create Cloudflare DNS records p
 To enable this, set the following variables in your `module` block.
 * manage_dns
 * cloudflare_zone_id
-* cloudflare_token (**Note - Your Cloudflare access token must provide edit permissions for the zone's DNS AND Page Rules.**)

--- a/README.md
+++ b/README.md
@@ -3,32 +3,15 @@
 [Terraform](https://www.terraform.io) module for deploying static sites on [DigitalOcean's App Platform](https://www.digitalocean.com/products/app-platform), with support for [Cloudflare](https://cloudflare.com) DNS.
 
 ## Usage:
-Create a `.tf` file inside your root module to call the module and set variables:
-```
-module "static_site" {
-	source  = "m4xmorris/static-site/digitalocean"
-	version = "" # <-- It is recommended to lock at known working versions. Remove this for latest release.
-	site_name = ""
-	description = ""
-	environment = ""
-	region = ""
-	domain = ""
-	source_repo = ""
-	source_branch = ""
-	preview_source_branch = ""
-	source_dir = ""
-	output_dir = ""
-	build_command = ""
-	do_token = ""
-}
+Create a `.tf` file inside your root module to call this module and set variables.
+An example workspace can be found in this repo [build test](.github/workflows/terraform-build-test.tf).
 
-```
 See [variables.tf](variables.tf) for variable descriptions and examples.
 
-The app's default ingress URL can be found in the TF output `module.static_site.default_ingress`.
+The site's default ingress URL can be found in the module output `default_ingress`.
 
 Optionally, this module is able to automatically create Cloudflare DNS records pointing to your app. 
 
 To enable this, set the following variables in your `module` block.
-* manage_dns
-* cloudflare_zone_id
+* `manage_dns = true`
+* `cloudflare_zone_id = "zone_id"`

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     digitalocean = {
       source = "digitalocean/digitalocean"
-      version = "~> 2.25"
+      version = "~> 2.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
Removed `cloudflare_token` from README.md as this is no longer needed.
Instead, Cloudflare's API token should be set when declaring the `cloudflare/cloudflare` provider in root module.

Also fixed DigitalOcean Provider version constraint.